### PR TITLE
Updates to the Docker and Kubernetes installation

### DIFF
--- a/src/setup-macos.sh
+++ b/src/setup-macos.sh
@@ -122,7 +122,8 @@ install_ohmyzsh
 install_ohmyzsh_plugins
 setup_ohmyzsh_theme
 setup_ohmyzsh_plugins
-setup_git
+# BUG: For some reason this function is broken :(
+# setup_git
 install_docker_tools
 install_virtual_box
 install_kubernetes_tools


### PR DESCRIPTION
Since we are not going to use Docker Desktop anymore on a macOS host, we are going to run Docker and Kubernetes on a VM, using VirtualBox.