### PR TITLE
Updates to scripts and tools related to Kubernetes 

### DIFF
--- a/.github/workflows/test-setup-macos.yml
+++ b/.github/workflows/test-setup-macos.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-10.15, macos-11, macos-12 ]
+        os: [ macos-11, macos-12 ]
         fail-fast: [ false ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/src/setup-macos.sh
+++ b/src/setup-macos.sh
@@ -124,7 +124,7 @@ function install_virtual_box() {
 }
 
 function install_kubernetes_tools() {
-    KUBERNETES_TOOLS=(stern kubernetes-cli minikube helm helmfile)
+    KUBERNETES_TOOLS=(stern kubernetes-cli minikube helm helmfile k9s)
     echo "Installing Kubernetes tools: ${KUBERNETES_TOOLS[*]}"
 
     for TOOL in "${KUBERNETES_TOOLS[@]}"; do

--- a/src/start-minikluster.sh
+++ b/src/start-minikluster.sh
@@ -10,7 +10,7 @@ start_minikube_cluster(){
 
     echo "Going to start minikube cluster with profile name: ${KLUSTER_PROFILE_NAME} 🌱"
 
-    minikube start --memory=8192 --cpus=3 --disk-size=30g --kubernetes-version=v1.21.3 --vm-driver=virtualbox -p "${KLUSTER_PROFILE_NAME}"
+    minikube start --memory=8192 --cpus=3 --disk-size=30g --kubernetes-version=v1.25.3 --vm-driver=virtualbox -p "${KLUSTER_PROFILE_NAME}"
 
     CLUSTER_STARTED=$?
 


### PR DESCRIPTION
1. Update the `start-minikluster` script to use the latest version of Kubernetes. 
2. Update the `setup-macos` script to also install [k9s](https://k9scli.io/)
3. Remove usage of the deprecated `macos-10.15` runner image