### PR TITLE
chore: Remove macos-11 from GH workflow

### DIFF
--- a/.github/workflows/test-setup-macos.yml
+++ b/.github/workflows/test-setup-macos.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-11, macos-12, macos-13]
+        os: [ macos-12, macos-13, macos-14 ]
         fail-fast: [ false ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test-setup-macos.yml
+++ b/.github/workflows/test-setup-macos.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-12, macos-13, macos-14 ]
+        os: [ macos-12, macos-13 ]
         fail-fast: [ false ]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
macOS 14 is the latest available image version of macOS and the macOS 11 image has been deprecated. 

Ref: https://github.com/actions/runner-images/tree/main?tab=readme-ov-file#available-images.