### PR TITLE
refactor(setup-macos): Add Brewfile

### DIFF
--- a/src/Brewfile
+++ b/src/Brewfile
@@ -1,0 +1,21 @@
+# Packages to be installed with brew
+
+## General tools
+brew 'tree'
+brew 'wget'
+brew 'watch'
+brew 'jq'
+brew 'yq'
+brew 'ccat'
+brew 'asdf'
+
+## Docker tools
+brew 'dive'
+
+## Kubernetes tools
+brew 'kubernetes-cli'
+brew 'stern'
+brew 'kubectx'
+brew 'helm'
+brew 'helmfile'
+brew 'k9s'


### PR DESCRIPTION
As a first step of simplifying the `setup-macos.sh` script, where the packages that are installed via `brew` will now be in this Brewfile.