### PR TITLE
ci: remove macos-13 from macOS workflow matrix

### DIFF
--- a/.github/workflows/test-setup-macos.yml
+++ b/.github/workflows/test-setup-macos.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-13, macos-14, macos-15 ]
+        os: [ macos-14, macos-15 ]
         fail-fast: [ false ]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Remove macos-13 from macOS matrix; runner no longer available. Replaced with macos-14 and macos-15.